### PR TITLE
don't touch /etc/pam.d/su when auth_wheel_group is undefined or False

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,7 @@
 - name: Divert original /etc/pam.d/su
   command: dpkg-divert --quiet --local --divert /etc/pam.d/su.dpkg-divert --rename /etc/pam.d/su
            creates=/etc/pam.d/su.dpkg-divert
+  when: auth_wheel_group is defined and auth_wheel_group
 
 - name: Configure 'su' command in PAM
   template:
@@ -35,6 +36,7 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
+  when: auth_wheel_group is defined and auth_wheel_group
 
 - name: Configure admin access in sudo
   template:


### PR DESCRIPTION
Hello Maciej,

I am trying to use debops.sftpusers. debops.sftpusers depends on debops.auth. However if left as is, debops.auth will setup a lot of stuff on the target host, that is not strictly required by debops.sftpusers, and in my case unwanted, since our system management methodology is different then the one that debops.auth is following (we don't have ldap, we aren't using special system groups et cetera.).

The provided patch will make debops.auth leave /etc/pam.d/su completely alone, if auth_wheel_group is undefined or False and thus not change it, if the depending systems tells debops.auth not to touch it.