### PR TITLE
Set UMASK value for useradd command to 0027

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,10 @@ v0.3.1
 - Add variable to specify umask for new home directories created by
   ``pam_mkhomedir`` PAM module. Default umask is set to ``0027``. [drybjed]
 
+- Set the default ``UMASK`` value for ``useradd`` command to ``0027``. All new
+  home directories will have ``0750`` permissions, which might affect content
+  accessibility for different applications. [drybjed]
+
 v0.3.0
 ------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,12 @@ auth_system_groups:
 auth_nsswitch: [ 'compat' ]
 
 
+# ---- Local user account configuration ----
+
+# Default umask for home directories of newly created user accounts
+auth_shadow_umask: '0027'
+
+
 # ---- /etc/ldap/ldap.conf options ----
 
 # Enable or disable /etc/ldap/ldap.conf configuration

--- a/tasks/login_passwd_shadow.yml
+++ b/tasks/login_passwd_shadow.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Set default umask for new home directories
+  lineinfile:
+    dest: '/etc/login.defs'
+    regexp: '^UMASK\s+'
+    line: 'UMASK\t\t{{ auth_shadow_umask }}'
+    backup: False
+    state: 'present'
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,9 @@
     validate: 'visudo -cf %s'
   when: auth_wheel_group is defined and auth_wheel_group
 
+- name: Configure local account options
+  include: login_passwd_shadow.yml
+
 - name: Check if /etc/ldap exists
   stat:
     path: '/etc/ldap'


### PR DESCRIPTION
This change will make all new home directories have 0750 permissions,
which might be important for web applications and other software.