### PR TITLE
Better control for optional PAM modules

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,9 @@ auth_shadow_umask: '0027'
 # Size of local password history, set to False to disable
 auth_pwhistory_remember: '5'
 
+# Enable password checking via cracklib
+auth_cracklib: True
+
 
 # ---- /etc/ldap/ldap.conf options ----
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,7 @@
     group: 'root'
     mode: '0644'
   notify: [ 'Update PAM common configuration' ]
+  when: auth_cracklib is defined and auth_cracklib
 
 - name: Configure PAM password history module
   include: pam_pwhistory.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,28 +40,9 @@
     mode: '0644'
   notify: [ 'Update PAM common configuration' ]
 
-- name: Check if password history database exists
-  stat:
-    path: '/etc/security/opasswd'
-  register: auth_register_opasswd
-
-- name: Configure password history database
-  file:
-    path: '/etc/security/opasswd'
-    state: 'touch'
-    owner: 'root'
-    group: 'root'
-    mode: '0600'
-  when: auth_register_opasswd is defined and not auth_register_opasswd.stat.exists
-
-- name: Configure pam_pwhistory
-  template:
-    src: 'usr/share/pam-configs/pwhistory.j2'
-    dest: '/usr/share/pam-configs/pwhistory'
-    owner: 'root'
-    group: 'root'
-    mode: '0644'
-  notify: [ 'Update PAM common configuration' ]
+- name: Configure PAM password history module
+  include: pam_pwhistory.yml
+  when: auth_pwhistory_remember is defined and auth_pwhistory_remember
 
 - name: Check if /etc/ldap exists
   stat:

--- a/tasks/pam_pwhistory.yml
+++ b/tasks/pam_pwhistory.yml
@@ -1,0 +1,24 @@
+---
+
+- name: Check if password history database exists
+  stat:
+    path: '/etc/security/opasswd'
+  register: auth_register_opasswd
+
+- name: Configure password history database
+  file:
+    path: '/etc/security/opasswd'
+    state: 'touch'
+    owner: 'root'
+    group: 'root'
+    mode: '0600'
+  when: auth_register_opasswd is defined and not auth_register_opasswd.stat.exists
+
+- name: Configure pam_pwhistory
+  template:
+    src: 'usr/share/pam-configs/pwhistory.j2'
+    dest: '/usr/share/pam-configs/pwhistory'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  notify: [ 'Update PAM common configuration' ]

--- a/templates/usr/share/pam-configs/pwhistory.j2
+++ b/templates/usr/share/pam-configs/pwhistory.j2
@@ -2,7 +2,6 @@
 
 # Remember previous local passwords to enforce rotation
 
-{% if auth_pwhistory_remember is defined and auth_pwhistory_remember %}
 Name: Unix password history
 Default: yes
 Priority: 500
@@ -12,6 +11,3 @@ Password:
 	required			pam_pwhistory.so use_authtok enforce_for_root remember={{ auth_pwhistory_remember }}
 Password-Initial:
 	required			pam_pwhistory.so enforce_for_root remember={{ auth_pwhistory_remember }}
-{% else %}
-# Password history is disabled
-{% endif %}


### PR DESCRIPTION
Update/add control switches for pam_cracklib and pam_pwhistory. Make sure, pam-auth-update won't be troubled.

Previously with `auth_pwhistory_remember: False`, the pwhistory module config file is installed empty, which resulted in the following messages and an empty ncurses module line:

    # pam-auth-update 
    Use of uninitialized value $fieldname in hash element at /usr/sbin/pam-auth-update line 689, <PROFILE> line 1.
    Use of uninitialized value $fieldname in hash element at /usr/sbin/pam-auth-update line 690, <PROFILE> line 1.
    [...]
    Use of uninitialized value in numeric comparison (<=>) at /usr/sbin/pam-auth-update line 101, <STDIN> line 3.
    Use of uninitialized value in numeric comparison (<=>) at /usr/sbin/pam-auth-update line 101, <STDIN> line 3.
    Use of uninitialized value in numeric comparison (<=>) at /usr/sbin/pam-auth-update line 101, <STDIN> line 3.
    Use of uninitialized value in join or string at /usr/sbin/pam-auth-update line 109, <STDIN> line 4.
    Use of uninitialized value in string eq at /usr/sbin/pam-auth-update line 140.
